### PR TITLE
Updated ARM filters in .bonsai.yml to use entity.system.arm_version.

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -31,7 +31,8 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   -  "entity.system.os == 'linux'"
-  -  "entity.system.arch == 'armv7'"
+  -  "entity.system.arch == 'arm'"
+  -  "entity.system.arm_version == 7"
 
 - platform: "OSX"
   arch: "amd64"


### PR DESCRIPTION
This has been discussed with Sensu in sensu/sensu-go#3563 and sensu-community/check-plugin-template#11. This makes it possible for arm7 devices (Rapsberry Pi) to get an asset without needing to modify the Asset Definition manually.